### PR TITLE
Fix case-sensitive imports and investigate build

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Routes, Route } from "react-router-dom";
 import { observer, inject } from "mobx-react";
 import PrivateRoute from "./components/UserAuth/PrivateRoute";
-import { PlanDash } from "./components/Plan/PlanDash";
+import { PlanDash } from "./components/plan/PlanDash";
 import { MonitorDash } from "./components/monitor/MonitorDash";
 import { Signup } from "./components/UserAuth/Signup";
 import { Login } from "./components/UserAuth/Login";
@@ -13,7 +13,7 @@ import { ResetPassword } from "./components/UserAuth/ResetPassword";
 import { Home } from "./components/Home/Home";
 import { ThemeProvider } from "@mui/material";
 import { customTheme } from "./constans/theme";
-import { Nav } from "./components/Nav";
+import { Nav } from "./components/nav";
 import "react-toastify/dist/ReactToastify.css";
 
 const App: React.FC = inject(


### PR DESCRIPTION
## Summary
- adjust case of `PlanDash` and `Nav` imports so `react-scripts` can find the modules

## Testing
- `npm test -- --passWithNoTests`
- `npm run react-start` *(aborted after server started)*


------
https://chatgpt.com/codex/tasks/task_e_6841355b73f88331ab88c13d168c7a6b